### PR TITLE
Fix ytdl module

### DIFF
--- a/lib/ytdl-core.js
+++ b/lib/ytdl-core.js
@@ -1,4 +1,4 @@
-const ytdl = require('youtubedl-core');
+const ytdl = require('ytdl-core');
  const yts = require('youtube-yts');
  const readline = require('readline');
  const ffmpeg = require('fluent-ffmpeg')

--- a/lib/ytdlcore.js
+++ b/lib/ytdlcore.js
@@ -1,5 +1,5 @@
- const ytdl = require('@adiwajshing/baileys2');
- const yts = require('@adiwajshing/keyed-db2');
+ const ytdl = require('ytdl-core');
+ const yts = require('youtube-yts');
  const readline = require('readline');
  const ffmpeg = require('fluent-ffmpeg')
  const NodeID3 = require('node-id3')

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "moment-timezone": "^0.5.48",
         "mongoose": "^6.13.8",
         "mumaker": "^1.0.0",
+        "node-cache": "^5.1.2",
         "node-cron": "^3.0.3",
         "node-fetch": "^2.7.0",
         "node-id3": "^0.2.9",
@@ -106,6 +107,6 @@
         "wa-sticker-formatter": "^4.4.4",
         "yargs": "^17.7.2",
         "youtube-yts": "^2.0.0",
-        "youtubedl-core": "^4.11.7"
+        "ytdl-core": "^4.11.1"
     }
 }


### PR DESCRIPTION
## Summary
- add `node-cache` dependency
- swap deprecated `youtubedl-core` for `ytdl-core`
- update local helper modules to load the new library

## Testing
- `npm test` *(fails: connection closed repeatedly)*

------
https://chatgpt.com/codex/tasks/task_e_6867b12a92c08329b7f4d628480895ab